### PR TITLE
Add support for includes

### DIFF
--- a/sake
+++ b/sake
@@ -117,24 +117,20 @@ else:
 with io.open(fname, "r") as fh:
     raw_text = fh.read()
     try:
-        sake_text = acts.expand_macros(raw_text, acts.gather_macros(raw_text))
+        sake_text, includes = acts.expand_macros(raw_text)
     except acts.InvalidMacroError as err:
         sys.stderr.write(err.message)
         sys.exit(1)
+    except acts.IncludeError as err:
+        sys.stderr.write(err.message)
+        sys.exit(1)
     except:
-        sys.stderr.write("Unspecified error trying to expand macros")
+        sys.stderr.write("Unspecified error trying to expand macros\n")
         sys.exit(1)
 
 
 
-try:
-    sakefile = yaml.load(sake_text)
-except yaml.YAMLError as exc:
-    sys.stderr.write("Error: Sakefile failed to parse as valid YAML\n")
-    if hasattr(exc, 'problem_mark'):
-        mark = exc.problem_mark
-        sys.stderr.write("Error near line {}\n".format(str(mark.line+1)))
-        sys.exit(1)
+sakefile = acts.parse(fname, sake_text, includes)
 if not audit.check_integrity(sakefile, args.verbose):
     sys.stderr.write("Error: Sakefile isn't written to specification\n")
     sys.exit(1)

--- a/test_sake.py
+++ b/test_sake.py
@@ -62,18 +62,6 @@ class TestActsFunction(unittest.TestCase):
         self.assertEqual("\"shakespeare's  sister\"", acts.escp(has_two_cons_spaces))
         self.assertEqual("\" well i wønder\"", acts.escp(has_more_spaces_and_unicode))
 
-    def test_gather_macros(self):
-        self.assertEqual(acts.gather_macros(self.mock_sakefile_for_macros),
-                         {"ask": "$hyness is nice",
-                          "rΩsholme": "at the last night      "})
-        self.assertRaises(acts.InvalidMacroError,
-                          acts.gather_macros,
-                          "---\n#!f4I7 ur3=this should fail\n...")
-        self.assertRaises(acts.InvalidMacroError,
-                          acts.gather_macros,
-                          "---\n#!===...")
-        self.assertFalse(acts.gather_macros("---\nhandsome devil\n..."))
-
     def test_expand_macros(self):
         # ATTENTION:
         #   there is a bug in python's template substitution that
@@ -82,14 +70,12 @@ class TestActsFunction(unittest.TestCase):
         temp = ["---", "#!ask=shyness is nice", "$ask me, ask me, $ask me",
                 "there are ruffians in $rusholme ($rΩsholme) and they steal $$",
                 "$askme, ${ask}me", "..."]
-        temp = "\n".join(temp)
-        solution = ["---", "#!ask=shyness is nice", "$hyness is nice me, ask me, $hyness is nice me",
+        temp = self.mock_sakefile_for_macros+"\n".join(temp)
+        solution = ["---", "#!ask=shyness is nice", "shyness is nice me, ask me, shyness is nice me",
                     "there are ruffians in $rusholme ($rΩsholme) and they steal $",
-                    "$askme, $hyness is niceme", "..."]
-        solution = "\n".join(solution)
-        self.assertEqual(acts.expand_macros(temp,
-                                 acts.gather_macros(self.mock_sakefile_for_macros)),
-                         solution)
+                    "$askme, shyness is niceme", "..."]
+        solution = self.mock_sakefile_for_macros+"\n".join(solution)
+        self.assertEqual(acts.expand_macros(temp)[0], solution)
 
     def test_get_help(self):
         self.assertEqual(acts.get_help(yaml.load(self.mock_sakefile_for_help)),


### PR DESCRIPTION
Differences:
- I moved some parsing logic to sakelib/acts.py, so it can recurse into itself.
- gather_macros was removed, as were its tests.
- expand_macros now returns 2 values.
- My text editor stripped out some EOL whitespace.
