### PR TITLE
Enhance include syntax

### DIFF
--- a/sakelib/acts.py
+++ b/sakelib/acts.py
@@ -160,7 +160,7 @@ def expand_macros(raw_text, macros={}):
     includes = {}
     result = []
     pattern = re.compile("#!\s*(\w+)\s*=\s*(.+$)", re.UNICODE)
-    ipattern = re.compile("#<\s*(\S+)\s+(optional|or\s+(.+))?$")
+    ipattern = re.compile("#<\s*(\S+)\s*(optional|or\s+(.+))?$")
     for line in raw_text.split("\n"):
         line = string.Template(line).safe_substitute(macros)
         # note that the line is appended to result before it is checked for macros


### PR DESCRIPTION
This lets you do the other include stuff I mentioned:

``` yaml
#< x.yaml optional
# including x.yaml is optional

#< x.yaml or Cannot find x.yaml
# including x.yaml is optional; if it can't be included, print "Cannot find x.yaml"

#< x.yaml
# sake as usual
```
