### PR TITLE
Add ignorable fields to targets

### DIFF
--- a/sakelib/audit.py
+++ b/sakelib/audit.py
@@ -146,7 +146,9 @@ def check_target_integrity(key, values, meta=False, all=False, parent=None):
                                                                      parent))
         sys.stderr.write("If it's not, it's missing a formula\n")
         return False
-    difference = our_keys_set - expected_fields
+    ignored_fields = set([field for field in our_keys_set\
+                          if field.strip().startswith("(ignore)")])
+    difference = our_keys_set - expected_fields - ignored_fields
     if difference:
         print("The following fields were not recognized and will be ignored")
         for item in difference:


### PR DESCRIPTION
I _know_ I went PR-happy lately...but you've got to admit that this is cool.

The basic idea is to add fields that are explicitly ignored:

``` yaml
target name:
    help: info
    formula: echo 123456
    # sake warns here
    some field: blah
    # but not here
    (ignore) some other field: blah 2
```
