### PR TITLE
Use yaml.safe_load to avoid warnings under PyYAML 5.1

### DIFF
--- a/sakelib/acts.py
+++ b/sakelib/acts.py
@@ -134,7 +134,7 @@ def find_standard_sakefile(settings):
 
 def parse(file, text, includes):
     try:
-        sakefile = yaml.load(text) or {}
+        sakefile = yaml.safe_load(text) or {}
     except yaml.YAMLError as exc:
         sys.stderr.write("Error: {} failed to parse as valid YAML\n".format(file))
         if hasattr(exc, 'problem_mark'):

--- a/sakelib/build.py
+++ b/sakelib/build.py
@@ -538,7 +538,7 @@ def build_this_graph(G, settings, dont_update_shas_of=None):
         in_mem_shas['files'] = {}
     with io.open(".shastore", "r") as fh:
         shas_on_disk = fh.read()
-    from_store = yaml.load(shas_on_disk)
+    from_store = yaml.safe_load(shas_on_disk)
     check_shastore_version(from_store, settings)
     if not from_store:
         write_shas_to_shastore(in_mem_shas)
@@ -546,7 +546,7 @@ def build_this_graph(G, settings, dont_update_shas_of=None):
         in_mem_shas['files'] = {}
         with io.open(".shastore", "r") as fh:
             shas_on_disk = fh.read()
-        from_store = yaml.load(shas_on_disk)
+        from_store = yaml.safe_load(shas_on_disk)
     # parallel
     if parallel:
         for line in parallel_sort(G):


### PR DESCRIPTION
Geez it's been [quite a while since I've last played with this code](https://github.com/tonyfischetti/sake/pull/70)... TLDR PyYAML 5.1 warns if you use yaml.load without a loader, 5.1 adds another function you can use instead of you need the fancy stuff, but Sakefiles never used any of that anyway so it's kinda pointless and switching to safe_load is easier.